### PR TITLE
Converting from degrees to radians on skewX and skewY transforms

### DIFF
--- a/src/svgren/Renderer.cpp
+++ b/src/svgren/Renderer.cpp
@@ -52,7 +52,7 @@ void Renderer::applyCairoTransformation(const svgdom::Transformable::Transformat
 			cairo_matrix_t matrix;
 			matrix.xx = 1;
 			matrix.yx = 0;
-			matrix.xy = std::tan(t.angle);
+			matrix.xy = std::tan(degToRad(t.angle));
 			matrix.yy = 1;
 			matrix.x0 = 0;
 			matrix.y0 = 0;
@@ -63,7 +63,7 @@ void Renderer::applyCairoTransformation(const svgdom::Transformable::Transformat
 		{
 			cairo_matrix_t matrix;
 			matrix.xx = 1;
-			matrix.yx = std::tan(t.angle);
+			matrix.yx = std::tan(degToRad(t.angle));
 			matrix.xy = 0;
 			matrix.yy = 1;
 			matrix.x0 = 0;


### PR DESCRIPTION
The transformations `skewX` and `skewY` should convert angle from degrees to radians when assigning tangent values on the transformation matrix on `Renderer.cpp`. I'm a bit surprised that this wasn't caught before.